### PR TITLE
Update the "Database Operator" scenario

### DIFF
--- a/cka/database-operator/intro.md
+++ b/cka/database-operator/intro.md
@@ -3,6 +3,7 @@
 
 ### Welcome !
 
-In this scenario, you'll be able to practice creating an ingress resource in Kubernetes!
+In this scenario, you'll learn how to install the Postgres Operator (PGO) from Crunchy Data and
+use it to create a ready to use PostgreSQL database.
 
 **ENJOY!**

--- a/cka/database-operator/step1.md
+++ b/cka/database-operator/step1.md
@@ -1,14 +1,8 @@
-First, go to GitHub and [fork the Postgres Operator examples](https://github.com/CrunchyData/postgres-operator-examples/fork) repository.
-
-Once you have forked this repo, you can clone your forked repo with the following commands:L
-```bash
-# set your username
-export GITHUB_USERNAME="<your-github-username>"
-```
+First, clone [the Postgres Operator examples](https://github.com/CrunchyData/postgres-operator-examples) repository from GitHub.
 
 ```bash
 # clone the repo
-git clone --depth 1 "https://github.com/${GITHUB_USERNAME}/postgres-operator-examples.git"
+git clone --depth 1 "https://github.com/CrunchyData/postgres-operator-examples.git"
 
 # change directory 
 cd postgres-operator-examples


### PR DESCRIPTION
The "Database Operator" scenario was incorrectly referring to ingresses in Kubernetes rather than the Postgres Operator.

It also asked the end-user to fork the examples repository for the Postgres Operator, which is not strictly required to complete this scenario.